### PR TITLE
fix: try fetch lost layer when unpack image

### DIFF
--- a/image.go
+++ b/image.go
@@ -384,7 +384,19 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string, opts ...Unpa
 	for _, layer := range layers {
 		unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, config.SnapshotOpts, config.ApplyOpts)
 		if err != nil {
-			return err
+			// layer not found in content, try to fetch layer and retry unpack
+			if errdefs.IsNotFound(err) {
+				if _, err2 := i.client.Pull(ctx, i.Name()+"@"+layer.Blob.Digest.String()); err2 != nil {
+					return fmt.Errorf("fetch lost layer failed: %w : %w", err2, err)
+				}
+				// retry
+				unpacked, err = rootfs.ApplyLayerWithOpts(ctx, layer, chain, sn, a, config.SnapshotOpts, config.ApplyOpts)
+				if err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
 		}
 
 		if unpacked {

--- a/pkg/cri/server/container_create.go
+++ b/pkg/cri/server/container_create.go
@@ -259,6 +259,9 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}()
 
 	var cntr containerd.Container
+	if c.config.ContainerdConfig.DiscardUnpackedLayers {
+		ctx = context.WithValue(ctx, containerd.DiscardUnpackedLayersKey{}, true)
+	}
 	if cntr, err = c.client.NewContainer(ctx, id, opts...); err != nil {
 		return nil, fmt.Errorf("failed to create containerd container: %w", err)
 	}

--- a/pkg/cri/server/sandbox_run.go
+++ b/pkg/cri/server/sandbox_run.go
@@ -173,6 +173,9 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata),
 		containerd.WithRuntime(ociRuntime.Type, runtimeOpts)}
 
+	if c.config.ContainerdConfig.DiscardUnpackedLayers {
+		ctx = context.WithValue(ctx, containerd.DiscardUnpackedLayersKey{}, true)
+	}
 	container, err := c.client.NewContainer(ctx, id, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create containerd container: %w", err)


### PR DESCRIPTION
If someone removes the content or snapshot by-pass the cri plugin, cir in-memory metadata think the image exists. When we create sandbox or container, we can't find snapshot and unpack from the content layer with the `discard_unpacked_layers` CRI config. In that case, we can try fetch the lost image layer to complete create container.

## example 
1. use `discard_unpacked_layers=true` CRI config with overlayfs, pulled OCI images.
2. change snapshotter to nydus gloablly.
3. try to create container with pulled OCI image before change sanpshotter.

In that case, we can't find snapshot with nydus sanpshotter. We can't unpack from the content store as well, because we use the `discard_unpacked_layers=true` config, the layer had discarded. We can try fetching the lost layer when unpacking image to fix this issue.
